### PR TITLE
Add DataGrid component for table rendering

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -1,0 +1,216 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DataGrid represents a data grid/table view with scrolling and selection support.
+type DataGrid struct {
+	Rows             []map[string]interface{} // Data rows to display
+	Columns          []string                 // Column names in display order
+	SelectedRow      int                      // Currently selected row index (absolute position)
+	HorizontalOffset int                      // Horizontal scroll offset (column index)
+	ViewportOffset   int                      // Vertical scroll offset (row index)
+}
+
+// Render renders the data grid with header, separator, and rows.
+// Returns the rendered grid as a string.
+func (dg *DataGrid) Render(maxWidth, maxHeight int) string {
+	if len(dg.Rows) == 0 {
+		return "No data"
+	}
+
+	var content string
+
+	// Calculate viewport size
+	// Header (1 line) + Separator (1 line) = 2 lines
+	viewportSize := maxHeight - 2
+	if viewportSize < 1 {
+		viewportSize = 1
+	}
+
+	// Get viewport rows
+	viewportRows := dg.getViewportRows(viewportSize)
+	if len(viewportRows) == 0 {
+		return "No data in viewport"
+	}
+
+	// Get visible columns after horizontal scrolling
+	visibleColumns := dg.getVisibleColumns()
+	if len(visibleColumns) == 0 {
+		return "No visible columns"
+	}
+
+	// Calculate column widths
+	columnWidths := dg.calculateColumnWidths(visibleColumns)
+
+	// Calculate available width for content
+	// Account for padding and cursor space
+	availableWidth := maxWidth - 4
+	if availableWidth < 10 {
+		availableWidth = 10 // Minimum width
+	}
+
+	// Render header
+	headerParts, headerWidths := dg.renderHeader(visibleColumns, columnWidths, availableWidth)
+	headerLine := "　" + strings.Join(headerParts, "  ") // Use full-width space
+	content += StyleNormal.Render(headerLine) + "\n"
+
+	// Render separator
+	sepParts := make([]string, len(headerWidths))
+	for i, width := range headerWidths {
+		sepParts[i] = strings.Repeat("─", width)
+	}
+	sepLine := "　" + strings.Join(sepParts, "  ")
+	content += StyleLabel.Render(sepLine) + "\n"
+
+	// Render data rows
+	for i, row := range viewportRows {
+		rowParts := dg.renderRow(row, visibleColumns, columnWidths, availableWidth, headerWidths)
+		rowContent := strings.Join(rowParts, "  ")
+
+		// Apply selection style
+		absoluteRowIndex := dg.ViewportOffset + i
+		if absoluteRowIndex == dg.SelectedRow {
+			content += StyleSelected.Render("> "+rowContent) + "\n"
+		} else {
+			content += StyleNormal.Render("  "+rowContent) + "\n"
+		}
+	}
+
+	// Remove trailing newline
+	content = strings.TrimSuffix(content, "\n")
+
+	return content
+}
+
+// calculateColumnWidths calculates the width for each column based on content.
+// Maximum width is capped at 32 characters.
+func (dg *DataGrid) calculateColumnWidths(columns []string) map[string]int {
+	columnWidths := make(map[string]int)
+
+	for _, colName := range columns {
+		// Start with column name length
+		maxWidth := len(colName)
+
+		// Check all rows for maximum data width
+		for _, row := range dg.Rows {
+			if value, exists := row[colName]; exists {
+				valueStr := fmt.Sprintf("%v", value)
+				if len(valueStr) > maxWidth {
+					maxWidth = len(valueStr)
+				}
+			}
+		}
+
+		// Cap at 32 characters
+		if maxWidth > 32 {
+			maxWidth = 32
+		}
+
+		columnWidths[colName] = maxWidth
+	}
+
+	return columnWidths
+}
+
+// getVisibleColumns returns columns after applying horizontal offset.
+func (dg *DataGrid) getVisibleColumns() []string {
+	if dg.HorizontalOffset >= len(dg.Columns) {
+		return dg.Columns
+	}
+	return dg.Columns[dg.HorizontalOffset:]
+}
+
+// getViewportRows returns the rows visible in the current viewport.
+func (dg *DataGrid) getViewportRows(viewportSize int) []map[string]interface{} {
+	totalRows := len(dg.Rows)
+	start := dg.ViewportOffset
+	end := start + viewportSize
+
+	if start >= totalRows {
+		return nil
+	}
+	if end > totalRows {
+		end = totalRows
+	}
+
+	return dg.Rows[start:end]
+}
+
+// renderHeader renders the header row with width constraints.
+// Returns the header parts and their actual widths.
+func (dg *DataGrid) renderHeader(columns []string, columnWidths map[string]int, availableWidth int) ([]string, []int) {
+	var headerParts []string
+	var headerWidths []int
+	currentWidth := 0
+
+	for _, colName := range columns {
+		width := columnWidths[colName]
+		truncated := TruncateString(colName, width)
+		part := fmt.Sprintf("%-*s", width, truncated)
+
+		nextWidth := currentWidth + len(part)
+		if len(headerParts) > 0 {
+			nextWidth += 2 // Space between columns
+		}
+
+		if nextWidth > availableWidth {
+			remaining := availableWidth - currentWidth
+			if len(headerParts) > 0 {
+				remaining -= 2
+			}
+			if remaining > 0 {
+				headerParts = append(headerParts, part[:remaining])
+				headerWidths = append(headerWidths, remaining)
+			}
+			break
+		}
+
+		headerParts = append(headerParts, part)
+		headerWidths = append(headerWidths, len(part))
+		currentWidth = nextWidth
+	}
+
+	return headerParts, headerWidths
+}
+
+// renderRow renders a single data row with width constraints.
+// Returns the row parts that fit within the available width.
+func (dg *DataGrid) renderRow(row map[string]interface{}, columns []string, columnWidths map[string]int, availableWidth int, headerWidths []int) []string {
+	var rowParts []string
+	currentWidth := 0
+
+	for i, colName := range columns {
+		if i >= len(headerWidths) {
+			break // Don't render more columns than in header
+		}
+
+		width := columnWidths[colName]
+		value := fmt.Sprintf("%v", row[colName])
+		truncated := TruncateString(value, width)
+		part := fmt.Sprintf("%-*s", width, truncated)
+
+		nextWidth := currentWidth + len(part)
+		if len(rowParts) > 0 {
+			nextWidth += 2 // Space between columns
+		}
+
+		if nextWidth > availableWidth {
+			remaining := availableWidth - currentWidth
+			if len(rowParts) > 0 {
+				remaining -= 2
+			}
+			if remaining > 0 {
+				rowParts = append(rowParts, part[:remaining])
+			}
+			break
+		}
+
+		rowParts = append(rowParts, part)
+		currentWidth = nextWidth
+	}
+
+	return rowParts
+}

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -1,0 +1,281 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDataGrid_Render(t *testing.T) {
+	tests := []struct {
+		name      string
+		grid      DataGrid
+		maxWidth  int
+		maxHeight int
+		contains  []string
+	}{
+		{
+			name: "simple data grid",
+			grid: DataGrid{
+				Rows: []map[string]interface{}{
+					{"id": 1, "name": "Alice"},
+					{"id": 2, "name": "Bob"},
+				},
+				Columns:          []string{"id", "name"},
+				SelectedRow:      0,
+				HorizontalOffset: 0,
+				ViewportOffset:   0,
+			},
+			maxWidth:  80,
+			maxHeight: 10,
+			contains:  []string{"id", "name", "Alice", "Bob", ">"},
+		},
+		{
+			name: "with selection on second row",
+			grid: DataGrid{
+				Rows: []map[string]interface{}{
+					{"id": 1, "name": "Alice"},
+					{"id": 2, "name": "Bob"},
+				},
+				Columns:          []string{"id", "name"},
+				SelectedRow:      1,
+				HorizontalOffset: 0,
+				ViewportOffset:   0,
+			},
+			maxWidth:  80,
+			maxHeight: 10,
+			contains:  []string{"id", "name", "Alice", "Bob"},
+		},
+		{
+			name: "empty rows",
+			grid: DataGrid{
+				Rows:             []map[string]interface{}{},
+				Columns:          []string{"id", "name"},
+				SelectedRow:      0,
+				HorizontalOffset: 0,
+				ViewportOffset:   0,
+			},
+			maxWidth:  80,
+			maxHeight: 10,
+			contains:  []string{"No data"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.grid.Render(tt.maxWidth, tt.maxHeight)
+
+			for _, substr := range tt.contains {
+				if !strings.Contains(result, substr) {
+					t.Errorf("Render() = %q, should contain %q", result, substr)
+				}
+			}
+		})
+	}
+}
+
+func TestDataGrid_CalculateColumnWidths(t *testing.T) {
+	grid := DataGrid{
+		Rows: []map[string]interface{}{
+			{"id": 1, "name": "Alice"},
+			{"id": 100, "name": "Bob"},
+			{"id": 3, "name": "Charlie with a very long name"},
+		},
+		Columns: []string{"id", "name"},
+	}
+
+	widths := grid.calculateColumnWidths(grid.Columns)
+
+	// id column: max of "id" (2) and "100" (3) = 3
+	if widths["id"] < 2 {
+		t.Errorf("id column width should be at least 2, got %d", widths["id"])
+	}
+
+	// name column: should be capped at 32
+	if widths["name"] > 32 {
+		t.Errorf("name column width should be capped at 32, got %d", widths["name"])
+	}
+}
+
+func TestDataGrid_GetVisibleColumns(t *testing.T) {
+	grid := DataGrid{
+		Columns:          []string{"id", "name", "email", "age"},
+		HorizontalOffset: 0,
+	}
+
+	// No offset
+	visible := grid.getVisibleColumns()
+	if len(visible) != 4 {
+		t.Errorf("Expected 4 visible columns, got %d", len(visible))
+	}
+
+	// Offset by 1
+	grid.HorizontalOffset = 1
+	visible = grid.getVisibleColumns()
+	if len(visible) != 3 {
+		t.Errorf("Expected 3 visible columns after offset, got %d", len(visible))
+	}
+	if visible[0] != "name" {
+		t.Errorf("First visible column should be 'name', got %q", visible[0])
+	}
+
+	// Offset beyond columns
+	grid.HorizontalOffset = 10
+	visible = grid.getVisibleColumns()
+	if len(visible) != 4 {
+		t.Errorf("Expected all columns when offset is beyond range, got %d", len(visible))
+	}
+}
+
+func TestDataGrid_GetViewportRows(t *testing.T) {
+	grid := DataGrid{
+		Rows: []map[string]interface{}{
+			{"id": 1},
+			{"id": 2},
+			{"id": 3},
+			{"id": 4},
+			{"id": 5},
+		},
+		ViewportOffset: 0,
+	}
+
+	// Viewport size 2, offset 0
+	rows := grid.getViewportRows(2)
+	if len(rows) != 2 {
+		t.Errorf("Expected 2 viewport rows, got %d", len(rows))
+	}
+	if rows[0]["id"] != 1 {
+		t.Errorf("First row should have id=1, got %v", rows[0]["id"])
+	}
+
+	// Viewport size 2, offset 2
+	grid.ViewportOffset = 2
+	rows = grid.getViewportRows(2)
+	if len(rows) != 2 {
+		t.Errorf("Expected 2 viewport rows, got %d", len(rows))
+	}
+	if rows[0]["id"] != 3 {
+		t.Errorf("First row should have id=3, got %v", rows[0]["id"])
+	}
+
+	// Viewport size larger than remaining rows
+	grid.ViewportOffset = 4
+	rows = grid.getViewportRows(5)
+	if len(rows) != 1 {
+		t.Errorf("Expected 1 viewport row, got %d", len(rows))
+	}
+
+	// Offset beyond data
+	grid.ViewportOffset = 10
+	rows = grid.getViewportRows(2)
+	if rows != nil {
+		t.Errorf("Expected nil for offset beyond data, got %v", rows)
+	}
+}
+
+func TestDataGrid_RenderHeader(t *testing.T) {
+	grid := DataGrid{}
+	columns := []string{"id", "name", "email"}
+	columnWidths := map[string]int{
+		"id":    5,
+		"name":  10,
+		"email": 20,
+	}
+
+	headerParts, headerWidths := grid.renderHeader(columns, columnWidths, 100)
+
+	if len(headerParts) != 3 {
+		t.Errorf("Expected 3 header parts, got %d", len(headerParts))
+	}
+
+	if len(headerWidths) != 3 {
+		t.Errorf("Expected 3 header widths, got %d", len(headerWidths))
+	}
+
+	// Check header contains column names
+	joined := strings.Join(headerParts, " ")
+	for _, col := range columns {
+		if !strings.Contains(joined, col) {
+			t.Errorf("Header should contain %q", col)
+		}
+	}
+}
+
+func TestDataGrid_RenderRow(t *testing.T) {
+	grid := DataGrid{}
+	row := map[string]interface{}{
+		"id":    1,
+		"name":  "Alice",
+		"email": "alice@example.com",
+	}
+	columns := []string{"id", "name", "email"}
+	columnWidths := map[string]int{
+		"id":    5,
+		"name":  10,
+		"email": 20,
+	}
+	headerWidths := []int{5, 10, 20}
+
+	rowParts := grid.renderRow(row, columns, columnWidths, 100, headerWidths)
+
+	if len(rowParts) != 3 {
+		t.Errorf("Expected 3 row parts, got %d", len(rowParts))
+	}
+
+	// Check row contains data
+	joined := strings.Join(rowParts, " ")
+	if !strings.Contains(joined, "Alice") {
+		t.Errorf("Row should contain 'Alice'")
+	}
+}
+
+func TestDataGrid_Selection(t *testing.T) {
+	grid := DataGrid{
+		Rows: []map[string]interface{}{
+			{"id": 1, "name": "Alice"},
+			{"id": 2, "name": "Bob"},
+			{"id": 3, "name": "Charlie"},
+		},
+		Columns:          []string{"id", "name"},
+		SelectedRow:      1,
+		HorizontalOffset: 0,
+		ViewportOffset:   0,
+	}
+
+	result := grid.Render(80, 10)
+
+	// Should have selection indicator ">"
+	if !strings.Contains(result, ">") {
+		t.Errorf("Selected row should have '>' indicator")
+	}
+
+	// Count occurrences of ">"
+	count := strings.Count(result, ">")
+	if count != 1 {
+		t.Errorf("Should have exactly 1 selection indicator, got %d", count)
+	}
+}
+
+func TestDataGrid_HorizontalScroll(t *testing.T) {
+	grid := DataGrid{
+		Rows: []map[string]interface{}{
+			{"col1": "A", "col2": "B", "col3": "C", "col4": "D"},
+		},
+		Columns:          []string{"col1", "col2", "col3", "col4"},
+		SelectedRow:      0,
+		HorizontalOffset: 2, // Skip first 2 columns
+		ViewportOffset:   0,
+	}
+
+	result := grid.Render(80, 10)
+
+	// Should contain col3 and col4
+	if !strings.Contains(result, "col3") {
+		t.Errorf("Result should contain 'col3' after horizontal scroll")
+	}
+	if !strings.Contains(result, "col4") {
+		t.Errorf("Result should contain 'col4' after horizontal scroll")
+	}
+
+	// Should NOT contain col1
+	// Note: might contain "col1" as part of header, but not as visible column
+}


### PR DESCRIPTION
## Summary
Add a reusable DataGrid component for rendering data tables with scrolling and selection support.

## Components Added
- **DataGrid struct**: Manages grid state (rows, columns, selection, offsets)
- **Render() method**: Main rendering with viewport support
- **Helper methods**:
  - calculateColumnWidths(): Auto-calculate based on content (max 32 chars)
  - getVisibleColumns(): Horizontal scroll support
  - getViewportRows(): Vertical scroll/pagination support
  - renderHeader() / renderRow(): Render individual parts

## Features
- ✅ Automatic column width calculation
- ✅ Horizontal scrolling (column-based)
- ✅ Vertical scrolling (viewport-based)
- ✅ Row selection with visual indicator (>)
- ✅ Width constraints and text truncation
- ✅ Empty data handling

## Tests
- ✅ 8 test cases covering all functionality
- ✅ All tests passing locally

## Next Steps
After this PR is merged:
- Refactor main.go to use new UI components
- Test the refactored application