### PR TITLE
fix: correct grid view height calculation

### DIFF
--- a/cmd/dito/main.go
+++ b/cmd/dito/main.go
@@ -1416,7 +1416,8 @@ func (m model) viewTableList() string {
 			}
 		} else if m.rightPaneMode == rightPaneModeList {
 			// グリッドビューモード
-			rightPaneHeight := m.height - 8
+			// rightPane全体の高さ(m.height-8)からSQLエリア(2行)を引く
+			rightPaneHeight := m.height - 10
 
 			// データの取得状態を確認
 			data, exists := m.tableData[selectedTableName]


### PR DESCRIPTION
## 問題
グリッドビューでusersテーブルを表示したときに、高さの計算がずれておりヘッダが切れていました。2行分高くなっていました。

## 原因
- SQLエリア（1行）+ セパレーター（1行）= 2行が表示されている
- しかし、DataGridに渡す高さがSQLエリア分を考慮していなかった
- 結果、2行分高くなりヘッダが切れていた

## 修正内容
```go
// 修正前
rightPaneHeight := m.height - 8

// 修正後
// rightPane全体の高さ(m.height-8)からSQLエリア(2行)を引く
rightPaneHeight := m.height - 10
```

DataGridに渡す高さを `m.height - 8` から `m.height - 10` に変更し、SQLエリア分（2行）を考慮するようにしました。

## Test plan
- [x] 全テスト通過
- [x] ビルド成功
- [x] 手動での動作確認（グリッドビューでヘッダが正しく表示される）

🤖 Generated with [Claude Code](https://claude.com/claude-code)