### PR TITLE
イベントハンドラーとモデルの分離

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1,0 +1,122 @@
+package app
+
+import (
+	"github.com/oracle/nosql-go-sdk/nosqldb"
+
+	"github.com/camikura/dito/internal/db"
+)
+
+// Screen represents the current screen type
+type Screen int
+
+const (
+	ScreenSelection Screen = iota
+	ScreenOnPremiseConfig
+	ScreenCloudConfig
+	ScreenTableList
+)
+
+// ConnectionStatus represents the connection state
+type ConnectionStatus int
+
+const (
+	StatusDisconnected ConnectionStatus = iota
+	StatusConnecting
+	StatusConnected
+	StatusError
+)
+
+// RightPaneMode represents the right pane display mode
+type RightPaneMode int
+
+const (
+	RightPaneModeSchema RightPaneMode = iota
+	RightPaneModeList   // Data list view
+	RightPaneModeDetail // Record detail view
+)
+
+// OnPremiseConfig holds on-premise connection configuration
+type OnPremiseConfig struct {
+	Endpoint      string
+	Port          string
+	Secure        bool
+	Focus         int // Currently focused field
+	Status        ConnectionStatus
+	ErrorMsg      string
+	ServerVersion string
+	CursorPos     int // Text input cursor position
+}
+
+// CloudConfig holds cloud connection configuration
+type CloudConfig struct {
+	Region        string
+	Compartment   string
+	AuthMethod    int // 0: OCI Config Profile, 1: Instance Principal, 2: Resource Principal
+	ConfigFile    string
+	Focus         int // Currently focused field
+	Status        ConnectionStatus
+	ErrorMsg      string
+	ServerVersion string
+	CursorPos     int // Text input cursor position
+}
+
+// Model is the main application model
+type Model struct {
+	Screen          Screen
+	Choices         []string
+	Cursor          int
+	Selected        map[int]struct{}
+	OnPremiseConfig OnPremiseConfig
+	CloudConfig     CloudConfig
+	Width           int
+	Height          int
+	// Table list screen
+	NosqlClient    *nosqldb.Client
+	Tables         []string
+	SelectedTable  int
+	Endpoint       string // Connection endpoint (for status display)
+	TableDetails   map[string]*db.TableDetailsResult
+	LoadingDetails bool
+	// Data display
+	RightPaneMode    RightPaneMode
+	TableData        map[string]*db.TableDataResult
+	DataOffset       int // Data fetch offset (for infinite scroll)
+	FetchSize        int // Number of rows to fetch at once
+	LoadingData      bool
+	SelectedDataRow  int // Selected row in data view mode (absolute position)
+	ViewportOffset   int // Display start position
+	ViewportSize     int // Number of rows to display at once
+	HorizontalOffset int // Horizontal scroll offset (column-based, 0-indexed)
+}
+
+// InitialModel returns the initial application model
+func InitialModel() Model {
+	return Model{
+		Screen:   ScreenSelection,
+		Choices:  []string{"Oracle NoSQL Cloud Service", "On-Premise"},
+		Selected: make(map[int]struct{}),
+		OnPremiseConfig: OnPremiseConfig{
+			Endpoint:  "localhost",
+			Port:      "8080",
+			Secure:    false,
+			Focus:     0,
+			Status:    StatusDisconnected,
+			CursorPos: 9, // End of "localhost"
+		},
+		CloudConfig: CloudConfig{
+			Region:      "us-ashburn-1",
+			Compartment: "",
+			AuthMethod:  0, // OCI Config Profile
+			ConfigFile:  "DEFAULT",
+			Focus:       0,
+			Status:      StatusDisconnected,
+			CursorPos:   12, // End of "us-ashburn-1"
+		},
+		TableDetails:  make(map[string]*db.TableDetailsResult),
+		RightPaneMode: RightPaneModeSchema,
+		TableData:     make(map[string]*db.TableDataResult),
+		DataOffset:    0,
+		FetchSize:     100, // Fetch 100 rows at once (infinite scroll)
+		ViewportSize:  10,
+	}
+}

--- a/internal/handlers/connection.go
+++ b/internal/handlers/connection.go
@@ -1,0 +1,210 @@
+package handlers
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/camikura/dito/internal/app"
+	"github.com/camikura/dito/internal/db"
+)
+
+// HandleCloudConfig handles the cloud connection configuration screen input
+func HandleCloudConfig(m app.Model, msg tea.KeyMsg) (app.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		// エディション選択画面に戻る
+		m.Screen = app.ScreenSelection
+		return m, nil
+	case "tab":
+		// 次のフィールドへ
+		m.CloudConfig.Focus = (m.CloudConfig.Focus + 1) % 8
+		// テキスト入力フィールドの場合、カーソルを末尾に
+		if m.CloudConfig.Focus == 0 {
+			m.CloudConfig.CursorPos = len(m.CloudConfig.Region)
+		} else if m.CloudConfig.Focus == 1 {
+			m.CloudConfig.CursorPos = len(m.CloudConfig.Compartment)
+		} else if m.CloudConfig.Focus == 5 {
+			m.CloudConfig.CursorPos = len(m.CloudConfig.ConfigFile)
+		}
+		return m, nil
+	case "shift+tab":
+		// 前のフィールドへ
+		m.CloudConfig.Focus--
+		if m.CloudConfig.Focus < 0 {
+			m.CloudConfig.Focus = 7
+		}
+		// テキスト入力フィールドの場合、カーソルを末尾に
+		if m.CloudConfig.Focus == 0 {
+			m.CloudConfig.CursorPos = len(m.CloudConfig.Region)
+		} else if m.CloudConfig.Focus == 1 {
+			m.CloudConfig.CursorPos = len(m.CloudConfig.Compartment)
+		} else if m.CloudConfig.Focus == 5 {
+			m.CloudConfig.CursorPos = len(m.CloudConfig.ConfigFile)
+		}
+		return m, nil
+	case "enter":
+		// ボタンが選択されている場合
+		if m.CloudConfig.Focus == 6 {
+			// 接続テスト - TODO: Cloud接続実装
+			m.CloudConfig.Status = app.StatusConnecting
+			m.CloudConfig.ErrorMsg = ""
+			return m, nil
+		} else if m.CloudConfig.Focus == 7 {
+			// 接続する - TODO: Cloud接続実装
+			m.CloudConfig.Status = app.StatusConnecting
+			m.CloudConfig.ErrorMsg = ""
+			return m, nil
+		}
+		return m, nil
+	case " ":
+		// ラジオボタンの選択
+		if m.CloudConfig.Focus >= 2 && m.CloudConfig.Focus <= 4 {
+			m.CloudConfig.AuthMethod = m.CloudConfig.Focus - 2
+		}
+		return m, nil
+	case "left":
+		// カーソルを左に移動
+		if m.CloudConfig.CursorPos > 0 {
+			m.CloudConfig.CursorPos--
+		}
+		return m, nil
+	case "right":
+		// カーソルを右に移動
+		var maxPos int
+		if m.CloudConfig.Focus == 0 {
+			maxPos = len(m.CloudConfig.Region)
+		} else if m.CloudConfig.Focus == 1 {
+			maxPos = len(m.CloudConfig.Compartment)
+		} else if m.CloudConfig.Focus == 5 {
+			maxPos = len(m.CloudConfig.ConfigFile)
+		}
+		if m.CloudConfig.CursorPos < maxPos {
+			m.CloudConfig.CursorPos++
+		}
+		return m, nil
+	case "backspace":
+		// テキストフィールドの入力削除
+		if m.CloudConfig.Focus == 0 && m.CloudConfig.CursorPos > 0 {
+			m.CloudConfig.Region = m.CloudConfig.Region[:m.CloudConfig.CursorPos-1] + m.CloudConfig.Region[m.CloudConfig.CursorPos:]
+			m.CloudConfig.CursorPos--
+		} else if m.CloudConfig.Focus == 1 && m.CloudConfig.CursorPos > 0 {
+			m.CloudConfig.Compartment = m.CloudConfig.Compartment[:m.CloudConfig.CursorPos-1] + m.CloudConfig.Compartment[m.CloudConfig.CursorPos:]
+			m.CloudConfig.CursorPos--
+		} else if m.CloudConfig.Focus == 5 && m.CloudConfig.CursorPos > 0 {
+			m.CloudConfig.ConfigFile = m.CloudConfig.ConfigFile[:m.CloudConfig.CursorPos-1] + m.CloudConfig.ConfigFile[m.CloudConfig.CursorPos:]
+			m.CloudConfig.CursorPos--
+		}
+		return m, nil
+	default:
+		// テキスト入力
+		if len(msg.String()) == 1 {
+			if m.CloudConfig.Focus == 0 {
+				m.CloudConfig.Region = m.CloudConfig.Region[:m.CloudConfig.CursorPos] + msg.String() + m.CloudConfig.Region[m.CloudConfig.CursorPos:]
+				m.CloudConfig.CursorPos++
+			} else if m.CloudConfig.Focus == 1 {
+				m.CloudConfig.Compartment = m.CloudConfig.Compartment[:m.CloudConfig.CursorPos] + msg.String() + m.CloudConfig.Compartment[m.CloudConfig.CursorPos:]
+				m.CloudConfig.CursorPos++
+			} else if m.CloudConfig.Focus == 5 {
+				m.CloudConfig.ConfigFile = m.CloudConfig.ConfigFile[:m.CloudConfig.CursorPos] + msg.String() + m.CloudConfig.ConfigFile[m.CloudConfig.CursorPos:]
+				m.CloudConfig.CursorPos++
+			}
+		}
+		return m, nil
+	}
+}
+
+// HandleOnPremiseConfig handles the on-premise connection configuration screen input
+func HandleOnPremiseConfig(m app.Model, msg tea.KeyMsg) (app.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		// エディション選択画面に戻る
+		m.Screen = app.ScreenSelection
+		return m, nil
+	case "tab":
+		// 次のフィールドへ
+		m.OnPremiseConfig.Focus = (m.OnPremiseConfig.Focus + 1) % 5
+		// テキスト入力フィールドの場合、カーソルを末尾に
+		if m.OnPremiseConfig.Focus == 0 {
+			m.OnPremiseConfig.CursorPos = len(m.OnPremiseConfig.Endpoint)
+		} else if m.OnPremiseConfig.Focus == 1 {
+			m.OnPremiseConfig.CursorPos = len(m.OnPremiseConfig.Port)
+		}
+		return m, nil
+	case "shift+tab":
+		// 前のフィールドへ
+		m.OnPremiseConfig.Focus--
+		if m.OnPremiseConfig.Focus < 0 {
+			m.OnPremiseConfig.Focus = 4
+		}
+		// テキスト入力フィールドの場合、カーソルを末尾に
+		if m.OnPremiseConfig.Focus == 0 {
+			m.OnPremiseConfig.CursorPos = len(m.OnPremiseConfig.Endpoint)
+		} else if m.OnPremiseConfig.Focus == 1 {
+			m.OnPremiseConfig.CursorPos = len(m.OnPremiseConfig.Port)
+		}
+		return m, nil
+	case "enter":
+		// ボタンが選択されている場合
+		if m.OnPremiseConfig.Focus == 3 {
+			// 接続テスト（テスト接続なので画面遷移しない）
+			m.OnPremiseConfig.Status = app.StatusConnecting
+			m.OnPremiseConfig.ErrorMsg = ""
+			return m, db.Connect(m.OnPremiseConfig.Endpoint, m.OnPremiseConfig.Port, true)
+		} else if m.OnPremiseConfig.Focus == 4 {
+			// 接続する（実接続なのでテーブル一覧画面に遷移）
+			m.OnPremiseConfig.Status = app.StatusConnecting
+			m.OnPremiseConfig.ErrorMsg = ""
+			return m, db.Connect(m.OnPremiseConfig.Endpoint, m.OnPremiseConfig.Port, false)
+		}
+		return m, nil
+	case " ":
+		// セキュアチェックボックスのトグル
+		if m.OnPremiseConfig.Focus == 2 {
+			m.OnPremiseConfig.Secure = !m.OnPremiseConfig.Secure
+		}
+		return m, nil
+	case "left":
+		// カーソルを左に移動
+		if m.OnPremiseConfig.CursorPos > 0 {
+			m.OnPremiseConfig.CursorPos--
+		}
+		return m, nil
+	case "right":
+		// カーソルを右に移動
+		var maxPos int
+		if m.OnPremiseConfig.Focus == 0 {
+			maxPos = len(m.OnPremiseConfig.Endpoint)
+		} else if m.OnPremiseConfig.Focus == 1 {
+			maxPos = len(m.OnPremiseConfig.Port)
+		}
+		if m.OnPremiseConfig.CursorPos < maxPos {
+			m.OnPremiseConfig.CursorPos++
+		}
+		return m, nil
+	case "backspace":
+		// テキストフィールドの入力削除
+		if m.OnPremiseConfig.Focus == 0 && m.OnPremiseConfig.CursorPos > 0 {
+			m.OnPremiseConfig.Endpoint = m.OnPremiseConfig.Endpoint[:m.OnPremiseConfig.CursorPos-1] + m.OnPremiseConfig.Endpoint[m.OnPremiseConfig.CursorPos:]
+			m.OnPremiseConfig.CursorPos--
+		} else if m.OnPremiseConfig.Focus == 1 && m.OnPremiseConfig.CursorPos > 0 {
+			m.OnPremiseConfig.Port = m.OnPremiseConfig.Port[:m.OnPremiseConfig.CursorPos-1] + m.OnPremiseConfig.Port[m.OnPremiseConfig.CursorPos:]
+			m.OnPremiseConfig.CursorPos--
+		}
+		return m, nil
+	default:
+		// テキスト入力
+		if len(msg.String()) == 1 {
+			if m.OnPremiseConfig.Focus == 0 {
+				m.OnPremiseConfig.Endpoint = m.OnPremiseConfig.Endpoint[:m.OnPremiseConfig.CursorPos] + msg.String() + m.OnPremiseConfig.Endpoint[m.OnPremiseConfig.CursorPos:]
+				m.OnPremiseConfig.CursorPos++
+			} else if m.OnPremiseConfig.Focus == 1 {
+				m.OnPremiseConfig.Port = m.OnPremiseConfig.Port[:m.OnPremiseConfig.CursorPos] + msg.String() + m.OnPremiseConfig.Port[m.OnPremiseConfig.CursorPos:]
+				m.OnPremiseConfig.CursorPos++
+			}
+		}
+		return m, nil
+	}
+}

--- a/internal/handlers/selection.go
+++ b/internal/handlers/selection.go
@@ -1,0 +1,35 @@
+package handlers
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/camikura/dito/internal/app"
+)
+
+// HandleSelection handles the connection selection screen input
+func HandleSelection(m app.Model, msg tea.KeyMsg) (app.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "q":
+		return m, tea.Quit
+	case "up", "shift+tab":
+		m.Cursor--
+		if m.Cursor < 0 {
+			m.Cursor = len(m.Choices) - 1
+		}
+	case "down", "tab":
+		m.Cursor = (m.Cursor + 1) % len(m.Choices)
+	case "enter":
+		// 0: Cloud, 1: On-Premise
+		switch m.Cursor {
+		case 0:
+			// Cloud: 接続設定画面に遷移
+			m.Screen = app.ScreenCloudConfig
+			return m, nil
+		case 1:
+			// On-Premise: 接続設定画面に遷移
+			m.Screen = app.ScreenOnPremiseConfig
+			return m, nil
+		}
+	}
+	return m, nil
+}

--- a/internal/handlers/table_list.go
+++ b/internal/handlers/table_list.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/camikura/dito/internal/app"
+	"github.com/camikura/dito/internal/db"
+	"github.com/camikura/dito/internal/views"
+)
+
+// HandleTableList handles the table list screen input
+func HandleTableList(m app.Model, msg tea.KeyMsg) (app.Model, tea.Cmd) {
+	oldSelection := m.SelectedTable
+
+	switch msg.String() {
+	case "ctrl+c", "q":
+		// クライアントをクローズしてから終了
+		if m.NosqlClient != nil {
+			m.NosqlClient.Close()
+		}
+		return m, tea.Quit
+	case "up", "k":
+		if m.RightPaneMode == app.RightPaneModeList || m.RightPaneMode == app.RightPaneModeDetail {
+			// グリッドビュー/レコードビュー: データ行を選択
+			if m.SelectedDataRow > 0 {
+				m.SelectedDataRow--
+				// ビューポートを調整（選択行がビューポートの上端より上になった場合）
+				if m.SelectedDataRow < m.ViewportOffset {
+					m.ViewportOffset = m.SelectedDataRow
+				}
+			}
+		} else {
+			// スキーマビューモード: テーブルを選択
+			if m.SelectedTable > 0 {
+				m.SelectedTable--
+			}
+		}
+	case "down", "j":
+		if m.RightPaneMode == app.RightPaneModeList || m.RightPaneMode == app.RightPaneModeDetail {
+			// グリッドビュー/レコードビュー: データ行を選択
+			tableName := m.Tables[m.SelectedTable]
+			if data, exists := m.TableData[tableName]; exists && data.Err == nil {
+				totalRows := len(data.Rows)
+				if m.SelectedDataRow < totalRows-1 {
+					m.SelectedDataRow++
+					// ビューポートを調整（選択行がビューポートの下端より下になった場合）
+					if m.SelectedDataRow >= m.ViewportOffset+m.ViewportSize {
+						m.ViewportOffset = m.SelectedDataRow - m.ViewportSize + 1
+					}
+
+					// 残り10行以内まで来たら、さらにデータがある場合は追加取得
+					remainingRows := totalRows - m.SelectedDataRow - 1
+					if remainingRows <= 10 && data.HasMore && !m.LoadingData {
+						m.LoadingData = true
+						// PRIMARY KEYを取得
+						var primaryKeys []string
+						if details, exists := m.TableDetails[tableName]; exists && details.Schema != nil && details.Schema.DDL != "" {
+							primaryKeys = views.ParsePrimaryKeysFromDDL(details.Schema.DDL)
+						}
+						return m, db.FetchMoreTableData(m.NosqlClient, tableName, m.FetchSize, primaryKeys, data.LastPKValues)
+					}
+				}
+			}
+		} else {
+			// スキーマビューモード: テーブルを選択
+			if m.SelectedTable < len(m.Tables)-1 {
+				m.SelectedTable++
+			}
+		}
+	case "h", "left":
+		// データビューモード: 左にスクロール
+		if m.RightPaneMode == app.RightPaneModeList {
+			if m.HorizontalOffset > 0 {
+				m.HorizontalOffset--
+			}
+		}
+	case "l", "right":
+		// データビューモード: 右にスクロール
+		if m.RightPaneMode == app.RightPaneModeList {
+			tableName := m.Tables[m.SelectedTable]
+			// カラム数を取得
+			var totalColumns int
+			if details, exists := m.TableDetails[tableName]; exists && details.Schema != nil && details.Schema.DDL != "" {
+				primaryKeys := views.ParsePrimaryKeysFromDDL(details.Schema.DDL)
+				columns := views.ParseColumnsFromDDL(details.Schema.DDL, primaryKeys)
+				totalColumns = len(columns)
+			} else if data, exists := m.TableData[tableName]; exists && len(data.Rows) > 0 {
+				totalColumns = len(data.Rows[0])
+			}
+			// 最後のカラムまでスクロールできるが、少なくとも1カラムは表示する
+			if m.HorizontalOffset < totalColumns-1 {
+				m.HorizontalOffset++
+			}
+		}
+	case "esc", "u":
+		if m.RightPaneMode == app.RightPaneModeDetail {
+			// レコードビュー → グリッドビュー
+			m.RightPaneMode = app.RightPaneModeList
+			return m, nil
+		} else if m.RightPaneMode == app.RightPaneModeList {
+			// グリッドビュー → スキーマビュー
+			m.RightPaneMode = app.RightPaneModeSchema
+			m.HorizontalOffset = 0 // 横スクロールをリセット
+			return m, nil
+		}
+		// スキーマビュー → 接続設定画面に戻る
+		m.Screen = app.ScreenOnPremiseConfig
+		return m, nil
+	case "enter", "o":
+		if m.RightPaneMode == app.RightPaneModeSchema {
+			// スキーマビュー → グリッドビュー
+			m.RightPaneMode = app.RightPaneModeList
+			m.SelectedDataRow = 0   // 行選択をリセット
+			m.ViewportOffset = 0    // ビューポートをリセット
+			m.HorizontalOffset = 0  // 横スクロールをリセット
+			// データ表示モードに切り替えたとき、データとテーブル詳細を取得
+			if len(m.Tables) > 0 {
+				tableName := m.Tables[m.SelectedTable]
+
+				// テーブル詳細がまだ取得されていない場合は取得
+				var cmds []tea.Cmd
+				if _, exists := m.TableDetails[tableName]; !exists {
+					m.LoadingDetails = true
+					cmds = append(cmds, db.FetchTableDetails(m.NosqlClient, tableName))
+				}
+
+				// データがまだ取得されていない場合は取得
+				if _, exists := m.TableData[tableName]; !exists {
+					m.LoadingData = true
+					// PRIMARY KEYを取得（テーブル詳細があれば）
+					var primaryKeys []string
+					if details, exists := m.TableDetails[tableName]; exists && details.Schema != nil && details.Schema.DDL != "" {
+						primaryKeys = views.ParsePrimaryKeysFromDDL(details.Schema.DDL)
+					}
+					cmds = append(cmds, db.FetchTableData(m.NosqlClient, tableName, m.FetchSize, primaryKeys))
+				}
+
+				if len(cmds) > 0 {
+					return m, tea.Batch(cmds...)
+				}
+			}
+		} else if m.RightPaneMode == app.RightPaneModeList {
+			// グリッドビュー → レコードビュー
+			m.RightPaneMode = app.RightPaneModeDetail
+		}
+	}
+
+	// テーブル選択が変わった場合、詳細を取得（スキーマビューモードのみ）
+	if m.RightPaneMode == app.RightPaneModeSchema && oldSelection != m.SelectedTable && len(m.Tables) > 0 {
+		tableName := m.Tables[m.SelectedTable]
+		// まだ取得していないテーブルの場合のみ取得
+		if _, exists := m.TableDetails[tableName]; !exists {
+			m.LoadingDetails = true
+			return m, db.FetchTableDetails(m.NosqlClient, tableName)
+		}
+	}
+
+	return m, nil
+}


### PR DESCRIPTION
## 概要
main.goからイベントハンドラーとモデル定義を分離し、コードの保守性と可読性を向上させました。

## 変更内容

### 新規作成したファイル
- **`internal/app/model.go`**: アプリケーションのモデル構造体と関連型を定義
  - `Model`構造体: アプリケーション全体の状態管理
  - `Screen`, `ConnectionStatus`, `RightPaneMode`: 画面状態の列挙型
  - `OnPremiseConfig`, `CloudConfig`: 接続設定の構造体
  - `InitialModel()`: モデルの初期化関数

- **`internal/handlers`パッケージ**: 各画面のイベント処理を分離
  - `selection.go`: 接続選択画面のキー入力ハンドラー（~25行）
  - `connection.go`: Cloud/On-Premise接続設定画面のハンドラー（~220行）
  - `table_list.go`: テーブル一覧画面のハンドラー（~160行）

### 変更したファイル
- **`cmd/dito/main.go`**: ハンドラーメソッドを削除し、handlers パッケージを使用
  - 1069行 → 590行（**479行削減**）
  - モデル構造体を`app.Model`の埋め込みに変更
  - すべてのフィールドと型をexportedに更新

## 効果
- ✅ main.goのコード量を45%削減
- ✅ 各画面のイベント処理が独立したファイルに分離され、責務が明確化
- ✅ ビジネスロジックの可読性が向上
- ✅ 将来的なテストの追加が容易になる構造
- ✅ 既存のテストはすべて成功

## テスト結果
```
ok  	github.com/camikura/dito/internal/db	(cached)
ok  	github.com/camikura/dito/internal/ui	(cached)
ok  	github.com/camikura/dito/internal/views	(cached)
```

## リファクタリングの進捗
- ✅ PR#13: ビュー描画ロジックの分離（internal/views）
- ✅ PR#14: データベース操作の分離（internal/db）
- ✅ **今回**: イベントハンドラーとモデルの分離（internal/app, internal/handlers）

🤖 Generated with [Claude Code](https://claude.com/claude-code)