### PR TITLE
fix: Reset connection status when returning to config screen

### DIFF
--- a/internal/handlers/table_list.go
+++ b/internal/handlers/table_list.go
@@ -104,7 +104,11 @@ func HandleTableList(m app.Model, msg tea.KeyMsg) (app.Model, tea.Cmd) {
 			return m, nil
 		}
 		// スキーマビュー → 接続設定画面に戻る
+		// 接続状態をリセット
 		m.Screen = app.ScreenOnPremiseConfig
+		m.OnPremiseConfig.Status = app.StatusDisconnected
+		m.OnPremiseConfig.ErrorMsg = ""
+		m.OnPremiseConfig.ServerVersion = ""
 		return m, nil
 	case "enter", "o":
 		if m.RightPaneMode == app.RightPaneModeSchema {

--- a/internal/handlers/table_list_test.go
+++ b/internal/handlers/table_list_test.go
@@ -180,12 +180,17 @@ func TestHandleTableList(t *testing.T) {
 			expectQuitCmd:      false,
 		},
 		{
-			name: "esc/u switches from schema to on-premise config",
+			name: "esc/u switches from schema to on-premise config and resets connection status",
 			initialModel: app.Model{
 				Screen:        app.ScreenTableList,
 				Tables:        []string{"users"},
 				SelectedTable: 0,
 				RightPaneMode: app.RightPaneModeSchema,
+				OnPremiseConfig: app.OnPremiseConfig{
+					Status:        app.StatusConnected,
+					ServerVersion: "Oracle NoSQL Database 23.1",
+					ErrorMsg:      "",
+				},
 			},
 			key:                "esc",
 			expectedScreen:     app.ScreenOnPremiseConfig,
@@ -363,6 +368,19 @@ func TestHandleTableList(t *testing.T) {
 				expectedOffset := tt.initialModel.HorizontalOffset - 1
 				if resultModel.HorizontalOffset != expectedOffset {
 					t.Errorf("HandleTableList() HorizontalOffset = %v, want %v", resultModel.HorizontalOffset, expectedOffset)
+				}
+			}
+
+			// Check connection status reset when returning to config screen
+			if (tt.key == "esc" || tt.key == "u") && tt.initialModel.RightPaneMode == app.RightPaneModeSchema && tt.expectedScreen == app.ScreenOnPremiseConfig {
+				if resultModel.OnPremiseConfig.Status != app.StatusDisconnected {
+					t.Errorf("HandleTableList() should reset OnPremiseConfig.Status to StatusDisconnected, got %v", resultModel.OnPremiseConfig.Status)
+				}
+				if resultModel.OnPremiseConfig.ServerVersion != "" {
+					t.Errorf("HandleTableList() should clear OnPremiseConfig.ServerVersion, got %v", resultModel.OnPremiseConfig.ServerVersion)
+				}
+				if resultModel.OnPremiseConfig.ErrorMsg != "" {
+					t.Errorf("HandleTableList() should clear OnPremiseConfig.ErrorMsg, got %v", resultModel.OnPremiseConfig.ErrorMsg)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary
Fixes a bug where the connection status incorrectly shows "Connected" when returning to the connection config screen from the table list screen.

## Changes
- Modified `internal/handlers/table_list.go` to reset connection status fields when navigating back to config screen
- Updated test in `internal/handlers/table_list_test.go` to verify the reset behavior

## Behavior
When pressing ESC or 'u' from schema view (table list screen), the application now:
- Resets `OnPremiseConfig.Status` to `StatusDisconnected`
- Clears `OnPremiseConfig.ServerVersion`
- Clears `OnPremiseConfig.ErrorMsg`

This ensures users see a clean disconnected state when they return to the configuration screen.

## Testing
- All existing tests pass
- Added verification in table_list_test.go for connection status reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)