### PR TITLE
refactor: Align record view labels with grid view column headers

### DIFF
--- a/internal/ui/vertical_table.go
+++ b/internal/ui/vertical_table.go
@@ -32,8 +32,10 @@ func (vt *VerticalTable) Render() string {
 	// Render each key-value pair
 	for _, key := range vt.Keys {
 		value := fmt.Sprintf("%v", vt.Data[key])
-		// Left-align the key with padding and use focused style for labels
-		label := StyleFocused.Render(fmt.Sprintf("%-*s", maxKeyWidth, key))
+		// Left-align the key with padding and use header style (without underline) for labels
+		// This matches the grid view column headers but without underline
+		labelStyle := StyleHeader.Copy().Underline(false)
+		label := labelStyle.Render(fmt.Sprintf("%-*s", maxKeyWidth, key))
 		result.WriteString(label + "  " + StyleNormal.Render(value) + "\n")
 	}
 


### PR DESCRIPTION
## Summary
Update record view labels to match grid view column header styling for visual consistency across views.

## Changes
- Record view labels now use the same style as grid view column headers:
  - Bold green text (`#00AA00`)
  - Same font weight
  - **Without underline** for cleaner appearance
- Updated `internal/ui/vertical_table.go` to use `StyleHeader.Copy().Underline(false)`

## Before
Record view labels used `StyleFocused` (cyan, bold)

## After  
Record view labels use `StyleHeader` without underline (green, bold) - matching grid headers

## Visual Consistency
This change ensures that:
- Column names appear the same in both grid and record views
- Users can easily recognize the same fields across different view modes
- Record view remains clean without unnecessary underlines

## Testing
- All existing tests pass ✓
- Build successful ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)